### PR TITLE
Neo mamba tool

### DIFF
--- a/examples/neo_transaction_tools_demo.py
+++ b/examples/neo_transaction_tools_demo.py
@@ -1,0 +1,435 @@
+"""
+Neo Transaction Tools Demo - Demonstrates 12 on-chain operation tools
+
+This example demonstrates the Neo N3 transaction/operation tools built on neo-mamba:
+
+  Read-only tools (no private key required):
+    1. NeoGetBalanceTool        - Query NEP-17 token balances
+    2. NeoTestInvokeTool        - Test invoke contracts (free, read-only)
+    3. NeoEstimateGasTool       - Estimate GAS cost before sending
+    4. NeoMultiSigCreateTool    - Create multi-signature accounts
+    5. NeoContractStorageTool   - Query contract storage entries
+
+  Transaction tools (require NEO_PRIVATE_KEY):
+    6. NeoTransferTool          - Transfer NEO/GAS/NEP-17 tokens
+    7. NeoNep11TransferTool     - Transfer NEP-11 NFTs
+    8. NeoInvokeContractTool    - Invoke contract methods (state-changing)
+    9. NeoBatchInvokeTool       - Batch multiple contract calls in one tx
+   10. NeoClaimGasTool          - Claim unclaimed GAS
+   11. NeoVoteTool              - Vote for consensus candidates
+   12. NeoDeployContractTool    - Deploy smart contracts
+
+Usage:
+    # Run read-only demos (no private key needed):
+    python examples/neo_transaction_tools_demo.py
+
+    # Run all demos including transactions (requires private key):
+    NEO_PRIVATE_KEY=<your_wif_or_hex> python examples/neo_transaction_tools_demo.py --live
+
+Uses testnet for all demonstrations.
+"""
+
+import asyncio
+import os
+import sys
+import json
+
+# ---------------------------------------------------------------------------
+# Test data (Neo N3 Testnet)
+# ---------------------------------------------------------------------------
+NETWORK = "testnet"
+
+# Well-known testnet addresses (no private key needed for read queries)
+TEST_ADDRESS = "NUTtedVrz5RgKAdCvtKiq3sRkb9pizcewe"
+TEST_CONTRACT_NEO = "0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5"
+TEST_CONTRACT_GAS = "0xd2a4cff31913016155e38e474a2c06d08be276cf"
+
+
+# ===========================================================================
+# Helper
+# ===========================================================================
+def section(title: str):
+    print(f"\n{'=' * 70}")
+    print(f"  {title}")
+    print(f"{'=' * 70}")
+
+
+def result_json(result) -> str:
+    """Pretty-print a ToolResult."""
+    if result.error:
+        return f"  ERROR: {result.error}"
+    data = result.output
+    if isinstance(data, dict):
+        return json.dumps(data, indent=2, default=str)
+    return str(data)
+
+
+# ===========================================================================
+# 1. NeoGetBalanceTool
+# ===========================================================================
+async def demo_get_balance():
+    section("1. NeoGetBalanceTool - Query token balances")
+
+    from spoon_toolkits.crypto.neo import NeoGetBalanceTool
+
+    tool = NeoGetBalanceTool()
+
+    # Query GAS balance
+    print(f"\n--- Query GAS balance for {TEST_ADDRESS} ---")
+    res = await tool.execute(address=TEST_ADDRESS, token="GAS", network=NETWORK)
+    print(result_json(res))
+
+    # Query NEO balance
+    print(f"\n--- Query NEO balance for {TEST_ADDRESS} ---")
+    res = await tool.execute(address=TEST_ADDRESS, token="NEO", network=NETWORK)
+    print(result_json(res))
+
+
+# ===========================================================================
+# 2. NeoTestInvokeTool
+# ===========================================================================
+async def demo_test_invoke():
+    section("2. NeoTestInvokeTool - Read-only contract invocation (free)")
+
+    from spoon_toolkits.crypto.neo import NeoTestInvokeTool
+
+    tool = NeoTestInvokeTool()
+
+    # Query NEO token symbol
+    print(f"\n--- Test invoke: NeoToken.symbol() ---")
+    res = await tool.execute(
+        contract_hash=TEST_CONTRACT_NEO,
+        method="symbol",
+        network=NETWORK,
+    )
+    print(result_json(res))
+
+    # Query GAS token decimals
+    print(f"\n--- Test invoke: GasToken.decimals() ---")
+    res = await tool.execute(
+        contract_hash=TEST_CONTRACT_GAS,
+        method="decimals",
+        network=NETWORK,
+    )
+    print(result_json(res))
+
+    # Query NEO totalSupply
+    print(f"\n--- Test invoke: NeoToken.totalSupply() ---")
+    res = await tool.execute(
+        contract_hash=TEST_CONTRACT_NEO,
+        method="totalSupply",
+        network=NETWORK,
+    )
+    print(result_json(res))
+
+
+# ===========================================================================
+# 3. NeoEstimateGasTool
+# ===========================================================================
+async def demo_estimate_gas():
+    section("3. NeoEstimateGasTool - Estimate GAS cost")
+
+    from spoon_toolkits.crypto.neo import NeoEstimateGasTool
+
+    tool = NeoEstimateGasTool()
+
+    # Estimate gas for querying symbol (read-only, cheap)
+    print(f"\n--- Estimate GAS: NeoToken.symbol() ---")
+    res = await tool.execute(
+        contract_hash=TEST_CONTRACT_NEO,
+        method="symbol",
+        network=NETWORK,
+    )
+    print(result_json(res))
+
+    # Estimate gas for a transfer (more expensive)
+    print(f"\n--- Estimate GAS: GasToken.balanceOf({TEST_ADDRESS}) ---")
+    res = await tool.execute(
+        contract_hash=TEST_CONTRACT_GAS,
+        method="balanceOf",
+        args=[{"type": "Hash160", "value": TEST_ADDRESS}],
+        signer_address=TEST_ADDRESS,
+        network=NETWORK,
+    )
+    print(result_json(res))
+
+
+# ===========================================================================
+# 4. NeoMultiSigCreateTool
+# ===========================================================================
+async def demo_multisig_create():
+    section("4. NeoMultiSigCreateTool - Create multi-signature account")
+
+    from spoon_toolkits.crypto.neo import NeoMultiSigCreateTool
+
+    tool = NeoMultiSigCreateTool()
+
+    # Create a 2-of-3 multisig using example public keys
+    # (These are well-known testnet committee member keys)
+    print("\n--- Create 2-of-3 multi-sig account ---")
+    res = await tool.execute(
+        public_keys=[
+            "02208aea0068c429a03316e37be0e3e8e21e6cda5442df4c5914a19b3a9b6de375",
+            "0306d3e7f18e6dd477d34ce3cfeca172a877f3c907cc6c2b66c295d1fcc76ff8f7",
+            "02158c4a4810fa2a6a12f7d33d835680429e1a68ae61161c5b3fbc98c7f1f17765",
+        ],
+        threshold=2,
+    )
+    print(result_json(res))
+
+
+# ===========================================================================
+# 5. NeoContractStorageTool
+# ===========================================================================
+async def demo_contract_storage():
+    section("5. NeoContractStorageTool - Query contract storage")
+
+    from spoon_toolkits.crypto.neo import NeoContractStorageTool
+
+    tool = NeoContractStorageTool()
+
+    # Query NEO token storage (first 5 entries)
+    print(f"\n--- Query NeoToken contract storage (first 5 entries) ---")
+    res = await tool.execute(
+        contract_hash=TEST_CONTRACT_NEO,
+        prefix="",
+        limit=5,
+        network=NETWORK,
+    )
+    print(result_json(res))
+
+
+# ===========================================================================
+# 6. NeoTransferTool
+# ===========================================================================
+async def demo_transfer():
+    section("6. NeoTransferTool - Transfer NEP-17 tokens")
+
+    from spoon_toolkits.crypto.neo import NeoTransferTool
+
+    tool = NeoTransferTool()
+
+    # Transfer a small amount of GAS on testnet
+    print(f"\n--- Transfer 0.001 GAS to {TEST_ADDRESS} ---")
+    res = await tool.execute(
+        to_address=TEST_ADDRESS,
+        amount="0.001",
+        token="GAS",
+        network=NETWORK,
+    )
+    print(result_json(res))
+
+
+# ===========================================================================
+# 7. NeoNep11TransferTool
+# ===========================================================================
+async def demo_nep11_transfer():
+    section("7. NeoNep11TransferTool - Transfer NEP-11 NFT")
+
+    from spoon_toolkits.crypto.neo import NeoNep11TransferTool
+
+    tool = NeoNep11TransferTool()
+
+    print("\n--- NFT transfer requires a specific NFT contract and token_id ---")
+    print("    Skipping live execution (needs owned NFT).")
+    print("    Usage example:")
+    print('    await tool.execute(')
+    print('        contract_hash="0x<nep11_contract>",')
+    print('        to_address="NXV2zsh...",')
+    print('        token_id="<hex_or_utf8_token_id>",')
+    print(f'        network="{NETWORK}",')
+    print("    )")
+
+
+# ===========================================================================
+# 8. NeoInvokeContractTool
+# ===========================================================================
+async def demo_invoke_contract():
+    section("8. NeoInvokeContractTool - State-changing contract invocation")
+
+    from spoon_toolkits.crypto.neo import NeoInvokeContractTool
+
+    tool = NeoInvokeContractTool()
+
+    # Example: invoke GAS token transfer (small amount to self)
+    # This is a real on-chain tx that costs GAS
+    print(f"\n--- Invoke: GasToken.transfer(self -> self, 1 satoshi) ---")
+    print("    This sends a minimal self-transfer to demonstrate invocation.")
+
+    # We need the sender address from the private key
+    from spoon_toolkits.crypto.neo.transfer_tools import (
+        _resolve_private_key,
+        _create_neo3_account,
+    )
+
+    key = _resolve_private_key()
+    account = _create_neo3_account(key)
+    sender = str(account.address)
+
+    res = await tool.execute(
+        contract_hash=TEST_CONTRACT_GAS,
+        method="transfer",
+        args=[
+            {"type": "Hash160", "value": sender},
+            {"type": "Hash160", "value": sender},
+            {"type": "Integer", "value": 1},
+            None,
+        ],
+        network=NETWORK,
+    )
+    print(result_json(res))
+
+
+# ===========================================================================
+# 9. NeoBatchInvokeTool
+# ===========================================================================
+async def demo_batch_invoke():
+    section("9. NeoBatchInvokeTool - Batch contract calls in one tx")
+
+    from spoon_toolkits.crypto.neo import NeoBatchInvokeTool
+    from spoon_toolkits.crypto.neo.transfer_tools import (
+        _resolve_private_key,
+        _create_neo3_account,
+    )
+
+    tool = NeoBatchInvokeTool()
+
+    key = _resolve_private_key()
+    account = _create_neo3_account(key)
+    sender = str(account.address)
+
+    # Batch: query NEO symbol + GAS symbol in one tx
+    # (Read-only methods batched in a state-changing tx for demo)
+    print("\n--- Batch invoke: NeoToken.symbol() + GasToken.symbol() ---")
+    res = await tool.execute(
+        calls=[
+            {"contract_hash": TEST_CONTRACT_NEO, "method": "symbol"},
+            {"contract_hash": TEST_CONTRACT_GAS, "method": "symbol"},
+        ],
+        network=NETWORK,
+    )
+    print(result_json(res))
+
+
+# ===========================================================================
+# 10. NeoClaimGasTool
+# ===========================================================================
+async def demo_claim_gas():
+    section("10. NeoClaimGasTool - Claim unclaimed GAS")
+
+    from spoon_toolkits.crypto.neo import NeoClaimGasTool
+
+    tool = NeoClaimGasTool()
+
+    print("\n--- Check and claim unclaimed GAS ---")
+    res = await tool.execute(network=NETWORK)
+    print(result_json(res))
+
+
+# ===========================================================================
+# 11. NeoVoteTool
+# ===========================================================================
+async def demo_vote():
+    section("11. NeoVoteTool - Vote for consensus candidate")
+
+    from spoon_toolkits.crypto.neo import NeoVoteTool
+
+    tool = NeoVoteTool()
+
+    print("\n--- Voting requires a valid candidate public key ---")
+    print("    Skipping live execution (needs known candidate pubkey on testnet).")
+    print("    Usage example:")
+    print('    await tool.execute(')
+    print('        candidate_pubkey="02208aea0068c429a03316e37be0e3e8e21e6cda...",')
+    print(f'        network="{NETWORK}",')
+    print("    )")
+
+
+# ===========================================================================
+# 12. NeoDeployContractTool
+# ===========================================================================
+async def demo_deploy_contract():
+    section("12. NeoDeployContractTool - Deploy smart contract")
+
+    from spoon_toolkits.crypto.neo import NeoDeployContractTool
+
+    tool = NeoDeployContractTool()
+
+    print("\n--- Contract deployment requires compiled .nef and .manifest.json files ---")
+    print("    Skipping live execution (needs contract artifacts).")
+    print("    Usage example:")
+    print('    await tool.execute(')
+    print('        nef_path="./my_contract.nef",')
+    print('        manifest_path="./my_contract.manifest.json",')
+    print(f'        network="{NETWORK}",')
+    print("    )")
+
+
+# ===========================================================================
+# Main
+# ===========================================================================
+async def main():
+    live_mode = "--live" in sys.argv
+
+    print("=" * 70)
+    print("  Neo N3 Transaction Tools Demo")
+    print("=" * 70)
+    print(f"  Network:    {NETWORK}")
+    print(f"  Mode:       {'LIVE (transactions enabled)' if live_mode else 'READ-ONLY (no private key needed)'}")
+    if live_mode:
+        pk = os.getenv("NEO_PRIVATE_KEY")
+        print(f"  Private key: {'set' if pk else 'NOT SET (transactions will fail)'}")
+    print("=" * 70)
+
+    # -----------------------------------------------------------------------
+    # Part 1: Read-only tools (always run, no private key needed)
+    # -----------------------------------------------------------------------
+    print("\n\n>>> PART 1: Read-Only Tools (no private key required) <<<\n")
+
+    await demo_get_balance()
+    await demo_test_invoke()
+    await demo_estimate_gas()
+    await demo_multisig_create()
+    await demo_contract_storage()
+
+    # -----------------------------------------------------------------------
+    # Part 2: Transaction tools (only with --live flag)
+    # -----------------------------------------------------------------------
+    if not live_mode:
+        section("PART 2: Transaction Tools (skipped)")
+        print("\n  Re-run with --live flag and NEO_PRIVATE_KEY set to enable:")
+        print("    NEO_PRIVATE_KEY=<your_wif> python examples/neo_transaction_tools_demo.py --live")
+        print("\n  Tools that would be demonstrated:")
+        print("    6.  NeoTransferTool        - Transfer GAS/NEO/NEP-17")
+        print("    7.  NeoNep11TransferTool   - Transfer NFTs")
+        print("    8.  NeoInvokeContractTool  - State-changing contract call")
+        print("    9.  NeoBatchInvokeTool     - Batch contract calls")
+        print("    10. NeoClaimGasTool        - Claim unclaimed GAS")
+        print("    11. NeoVoteTool            - Vote for candidates")
+        print("    12. NeoDeployContractTool  - Deploy contracts")
+        return
+
+    print("\n\n>>> PART 2: Transaction Tools (LIVE - costs testnet GAS) <<<\n")
+
+    await demo_transfer()
+    await demo_nep11_transfer()
+    await demo_invoke_contract()
+    await demo_batch_invoke()
+    await demo_claim_gas()
+    await demo_vote()
+    await demo_deploy_contract()
+
+    # -----------------------------------------------------------------------
+    # Summary
+    # -----------------------------------------------------------------------
+    section("Demo Complete")
+    print("\n  12 Neo transaction/operation tools demonstrated:")
+    print("  Read-only:    NeoGetBalance, NeoTestInvoke, NeoEstimateGas,")
+    print("                NeoMultiSigCreate, NeoContractStorage")
+    print("  Transactions: NeoTransfer, NeoNep11Transfer, NeoInvokeContract,")
+    print("                NeoBatchInvoke, NeoClaimGas, NeoVote, NeoDeployContract")
+    print()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/neo_transaction_tools_demo.py
+++ b/examples/neo_transaction_tools_demo.py
@@ -438,7 +438,22 @@ async def main():
     if live_mode:
         pk = os.getenv("NEO_PRIVATE_KEY")
         print(f"  Private key: {'set' if pk else 'NOT SET (transactions will fail)'}")
+        if pk:
+            # Derive address for confirmation
+            try:
+                from neo3.wallet.account import Account
+                acct = Account.from_wif(pk)
+                print(f"  Address:    {acct.address}")
+            except Exception:
+                pass
     print("=" * 70)
+
+    # Safety confirmation for live mode
+    if live_mode and "--yes" not in sys.argv:
+        answer = input("\n  This will send REAL transactions on testnet. Continue? [y/N] ")
+        if answer.strip().lower() not in ("y", "yes"):
+            print("  Aborted.")
+            return
 
     # -----------------------------------------------------------------------
     # Part 1: Read-only tools (always run, no private key needed)

--- a/spoon_toolkits/crypto/neo/__init__.py
+++ b/spoon_toolkits/crypto/neo/__init__.py
@@ -1,5 +1,9 @@
 """Neo blockchain tools module"""
 
+# Apply neo-mamba compatibility fixes before importing any tools
+from . import _compat as _neo_compat
+_neo_compat.apply()
+
 # Address tools
 from .address_tools import (
     GetAddressCountTool,
@@ -97,6 +101,46 @@ from .governance_tools import (
     GetCommitteeInfoTool,
 )
 
+# Transfer tools (on-chain transaction sending)
+from .transfer_tools import (
+    NeoTransferTool,
+    NeoNep11TransferTool,
+)
+
+# Contract invocation tools (on-chain + test invoke + batch + estimate)
+from .invoke_tools import (
+    NeoInvokeContractTool,
+    NeoTestInvokeTool,
+    NeoBatchInvokeTool,
+    NeoEstimateGasTool,
+)
+
+# Balance tools
+from .balance_tools import (
+    NeoGetBalanceTool,
+)
+
+# Governance action tools (claim GAS, vote)
+from .governance_action_tools import (
+    NeoClaimGasTool,
+    NeoVoteTool,
+)
+
+# Contract deployment tools
+from .deploy_tools import (
+    NeoDeployContractTool,
+)
+
+# Multi-signature tools
+from .multisig_tools import (
+    NeoMultiSigCreateTool,
+)
+
+# Contract storage tools
+from .storage_tools import (
+    NeoContractStorageTool,
+)
+
 # Provider
 from .neo_provider import NeoProvider
 from .base import get_provider
@@ -178,7 +222,33 @@ __all__ = [
 
     # Governance tools (1)
     "GetCommitteeInfoTool",
-    
+
+    # Transfer tools (2)
+    "NeoTransferTool",
+    "NeoNep11TransferTool",
+
+    # Contract invocation tools (4)
+    "NeoInvokeContractTool",
+    "NeoTestInvokeTool",
+    "NeoBatchInvokeTool",
+    "NeoEstimateGasTool",
+
+    # Balance tools (1)
+    "NeoGetBalanceTool",
+
+    # Governance action tools (2)
+    "NeoClaimGasTool",
+    "NeoVoteTool",
+
+    # Contract deployment tools (1)
+    "NeoDeployContractTool",
+
+    # Multi-signature tools (1)
+    "NeoMultiSigCreateTool",
+
+    # Contract storage tools (1)
+    "NeoContractStorageTool",
+
     # Provider
     "NeoProvider",
     "get_provider",

--- a/spoon_toolkits/crypto/neo/_compat.py
+++ b/spoon_toolkits/crypto/neo/_compat.py
@@ -1,0 +1,43 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+
+
+def apply():
+    """Apply all neo-mamba compatibility fixes (idempotent)."""
+    global _PATCHED
+    if _PATCHED:
+        return
+    _PATCHED = True
+
+    from neo3.api import noderpc
+
+    # -- Fix 1: raise default timeout from 3 s to 30 s --------------------
+    _original_init = noderpc.RPCClient.__init__
+
+    def _init_with_longer_timeout(self, url: str, timeout: float = 30.0):
+        _original_init(self, url, timeout)
+
+    noderpc.RPCClient.__init__ = _init_with_longer_timeout
+
+    # -- Fix 2: robust error handling in _do_post --------------------------
+    async def _safe_do_post(self, method, params=None, id=0, jsonrpc_version="2.0"):
+        json_payload = {
+            "jsonrpc": jsonrpc_version,
+            "id": id,
+            "method": method,
+            "params": params if params else [],
+        }
+        response = await noderpc.RPCClient._post(self, json_payload)
+        error = response.get("error")
+        if error:
+            if isinstance(error, dict):
+                raise noderpc.JsonRpcError(**error)
+            raise noderpc.JsonRpcError(code=-1, message=str(error))
+        return response["result"]
+
+    noderpc.NeoRpcClient._do_post = _safe_do_post
+
+    logger.debug("neo-mamba compatibility patches applied")

--- a/spoon_toolkits/crypto/neo/_compat.py
+++ b/spoon_toolkits/crypto/neo/_compat.py
@@ -17,8 +17,9 @@ def apply():
     # -- Fix 1: raise default timeout from 3 s to 30 s --------------------
     _original_init = noderpc.RPCClient.__init__
 
-    def _init_with_longer_timeout(self, url: str, timeout: float = 30.0):
-        _original_init(self, url, timeout)
+    def _init_with_longer_timeout(self, *args, **kwargs):
+        kwargs.setdefault("timeout", 30.0)
+        _original_init(self, *args, **kwargs)
 
     noderpc.RPCClient.__init__ = _init_with_longer_timeout
 

--- a/spoon_toolkits/crypto/neo/_helpers.py
+++ b/spoon_toolkits/crypto/neo/_helpers.py
@@ -1,0 +1,133 @@
+"""Shared helpers for Neo on-chain tools.
+
+Provides common utilities used across multiple Neo tool modules:
+- RPC URL resolution
+- Private key resolution (env / vault / explicit)
+- neo3 account creation
+- Transaction state checking (VMState)
+- Error message sanitization
+"""
+
+import os
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# RPC configuration
+# ---------------------------------------------------------------------------
+DEFAULT_MAINNET_RPC = "https://mainmagnet.ngd.network:443"
+DEFAULT_TESTNET_RPC = "https://testmagnet.ngd.network:443"
+
+
+def get_rpc_url(network: str) -> str:
+    """Resolve RPC URL from network name and environment variables."""
+    if network == "mainnet":
+        return os.getenv("NEO_MAINNET_RPC", DEFAULT_MAINNET_RPC)
+    return os.getenv("NEO_TESTNET_RPC", DEFAULT_TESTNET_RPC)
+
+
+# ---------------------------------------------------------------------------
+# Key management
+# ---------------------------------------------------------------------------
+def resolve_private_key(private_key: Optional[str] = None) -> str:
+    """Resolve private key from parameter, env var, or vault.
+
+    Priority: explicit param -> plain env -> vault-decrypted env.
+
+    Returns:
+        Private key string (WIF or hex).
+
+    Raises:
+        ValueError: if no private key can be resolved.
+    """
+    from .signers import ENV_PRIVATE_KEY, _is_encrypted, _get_private_key_from_vault
+
+    if private_key:
+        return private_key.strip()
+
+    env_key = os.getenv(ENV_PRIVATE_KEY)
+    if env_key and not _is_encrypted(env_key):
+        return env_key.strip()
+
+    vault_key = _get_private_key_from_vault()
+    if vault_key:
+        return vault_key.strip()
+
+    raise ValueError(
+        f"No private key available. Provide private_key parameter or set {ENV_PRIVATE_KEY} env var."
+    )
+
+
+def create_neo3_account(private_key: str):
+    """Create a neo3 Account from a WIF or hex private key.
+
+    Returns:
+        neo3.wallet.account.Account instance.
+    """
+    from neo3.wallet.account import Account
+
+    # Try WIF first
+    try:
+        return Account.from_wif(private_key)
+    except Exception:
+        pass
+
+    # Try hex private key
+    key_hex = private_key
+    if key_hex.startswith("0x"):
+        key_hex = key_hex[2:]
+    key_bytes = bytes.fromhex(key_hex)
+    return Account.from_private_key(key_bytes)
+
+
+# ---------------------------------------------------------------------------
+# Transaction state helpers
+# ---------------------------------------------------------------------------
+def is_halt(receipt) -> bool:
+    """Check whether a transaction receipt indicates successful execution.
+
+    Handles both ``VMState`` enum (from ``invoke``) and plain string
+    (from ``test_invoke``).
+    """
+    try:
+        from neo3.vm import VMState
+        if receipt.state == VMState.HALT:
+            return True
+    except ImportError:
+        pass
+    # Fallback: string comparison for test_invoke or unknown formats
+    return "HALT" in str(receipt.state)
+
+
+def state_label(receipt) -> str:
+    """Return a human-readable state string from a receipt."""
+    try:
+        from neo3.vm import VMState
+        if receipt.state == VMState.HALT:
+            return "HALT"
+    except ImportError:
+        pass
+    raw = str(receipt.state)
+    if "HALT" in raw:
+        return "HALT"
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Error formatting
+# ---------------------------------------------------------------------------
+def sanitize_error(exception_detail) -> str:
+    """Sanitize an internal exception detail for external consumption.
+
+    Strips overly verbose stack traces, keeping only the first line.
+    """
+    if not exception_detail:
+        return ""
+    msg = str(exception_detail)
+    first_line = msg.split("\n")[0].strip()
+    if len(first_line) > 200:
+        first_line = first_line[:200] + "..."
+    return first_line

--- a/spoon_toolkits/crypto/neo/balance_tools.py
+++ b/spoon_toolkits/crypto/neo/balance_tools.py
@@ -1,0 +1,126 @@
+"""Neo balance query tool.
+
+Query NEP-17 token balances (NEO, GAS, or custom tokens) directly via RPC
+using neo-mamba's ChainFacade and NEP17Contract wrappers.
+"""
+
+import logging
+from typing import Optional
+
+from pydantic import Field
+
+from spoon_ai.tools.base import BaseTool, ToolResult
+from .transfer_tools import _get_rpc_url
+
+logger = logging.getLogger(__name__)
+
+
+class NeoGetBalanceTool(BaseTool):
+    """Get NEP-17 token balance for a Neo N3 address.
+
+    Queries balance directly via RPC node using neo-mamba. Supports NEO, GAS,
+    and any NEP-17 compliant token. Returns human-readable amounts with decimals.
+    """
+
+    name: str = "neo_get_balance"
+    description: str = (
+        "Get NEP-17 token balance for a Neo N3 address. "
+        "Supports NEO, GAS, or any NEP-17 token by contract hash. "
+        "Useful when you need to check how much NEO, GAS, or other tokens an address holds. "
+        "Returns balance in human-readable format with proper decimal handling."
+    )
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "network": {
+                "type": "string",
+                "enum": ["mainnet", "testnet"],
+                "description": "Neo network to use",
+                "default": "testnet",
+            },
+            "address": {
+                "type": "string",
+                "description": "Neo address to query (Base58 format, e.g. NXV2zshzasps7nqz2kcrv69zWhksVSG87D)",
+            },
+            "token": {
+                "type": "string",
+                "description": "Token to query: 'NEO', 'GAS', or a contract hash (0x-prefixed). Defaults to GAS.",
+                "default": "GAS",
+            },
+        },
+        "required": ["address"],
+    }
+
+    network: str = Field(default="testnet")
+    address: Optional[str] = Field(default=None)
+    token: str = Field(default="GAS")
+
+    async def execute(
+        self,
+        address: Optional[str] = None,
+        token: Optional[str] = None,
+        network: Optional[str] = None,
+    ) -> ToolResult:
+        try:
+            network = network or self.network or "testnet"
+            address = address or self.address
+            token = token or self.token or "GAS"
+
+            if not address:
+                return ToolResult(error="Missing address parameter")
+
+            from neo3.api.wrappers import (
+                ChainFacade,
+                NEP17Contract,
+                NeoToken,
+                GasToken,
+            )
+            from neo3.core import types
+
+            rpc_url = _get_rpc_url(network)
+            facade = ChainFacade(rpc_host=rpc_url)
+
+            # Resolve token contract
+            token_upper = token.upper()
+            if token_upper == "NEO":
+                token_contract = NeoToken()
+                token_symbol = "NEO"
+            elif token_upper == "GAS":
+                token_contract = GasToken()
+                token_symbol = "GAS"
+            else:
+                contract_hash = token
+                if not contract_hash.startswith("0x"):
+                    contract_hash = f"0x{contract_hash}"
+                token_contract = NEP17Contract(types.UInt160.from_string(contract_hash))
+                # Query symbol
+                try:
+                    symbol_receipt = await facade.test_invoke(token_contract.symbol())
+                    token_symbol = symbol_receipt.result
+                except Exception:
+                    token_symbol = contract_hash
+
+            # Query balance (friendly = human-readable with decimals)
+            balance_receipt = await facade.test_invoke(
+                token_contract.balance_of_friendly(address)
+            )
+            balance = balance_receipt.result
+
+            # Also get raw balance for precision
+            raw_receipt = await facade.test_invoke(
+                token_contract.balance_of(address)
+            )
+            raw_balance = raw_receipt.result
+
+            return ToolResult(output={
+                "address": address,
+                "token": token_symbol,
+                "balance": balance,
+                "raw_balance": raw_balance,
+                "network": network,
+            })
+
+        except Exception as e:
+            err_msg = str(e) or repr(e)
+            logger.error(f"NeoGetBalanceTool error: {err_msg}")
+            return ToolResult(error=f"Balance query failed: {err_msg}")

--- a/spoon_toolkits/crypto/neo/deploy_tools.py
+++ b/spoon_toolkits/crypto/neo/deploy_tools.py
@@ -1,0 +1,166 @@
+"""Neo smart contract deployment tool.
+
+Deploy smart contracts to the Neo N3 blockchain using neo-mamba's ChainFacade.
+Supports loading NEF (Neo Executable Format) and manifest files from disk or raw bytes.
+"""
+
+import logging
+from typing import Optional
+
+from pydantic import Field
+
+from spoon_ai.tools.base import BaseTool, ToolResult
+from .transfer_tools import (
+    _get_rpc_url,
+    _resolve_private_key,
+    _create_neo3_account,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class NeoDeployContractTool(BaseTool):
+    """Deploy a smart contract to the Neo N3 blockchain.
+
+    Loads compiled NEF and manifest files, then deploys them via a transaction.
+    Returns the deployed contract hash and transaction details.
+    """
+
+    name: str = "neo_deploy_contract"
+    description: str = (
+        "Deploy a smart contract to the Neo N3 blockchain. "
+        "Requires compiled NEF (Neo Executable Format) and manifest JSON files. "
+        "Useful when you need to deploy a new smart contract on-chain. "
+        "Returns the new contract hash, transaction hash, and deployment details."
+    )
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "network": {
+                "type": "string",
+                "enum": ["mainnet", "testnet"],
+                "description": "Neo network to use",
+                "default": "testnet",
+            },
+            "nef_path": {
+                "type": "string",
+                "description": "Path to the compiled .nef file",
+            },
+            "manifest_path": {
+                "type": "string",
+                "description": "Path to the contract .manifest.json file",
+            },
+            "data": {
+                "type": "object",
+                "description": "Optional data passed to the contract's _deploy method",
+            },
+            "private_key": {
+                "type": "string",
+                "description": "Deployer private key (WIF or hex). If omitted, uses NEO_PRIVATE_KEY env var.",
+            },
+        },
+        "required": ["nef_path", "manifest_path"],
+    }
+
+    network: str = Field(default="testnet")
+    nef_path: Optional[str] = Field(default=None)
+    manifest_path: Optional[str] = Field(default=None)
+    data: Optional[dict] = Field(default=None)
+    private_key: Optional[str] = Field(default=None)
+
+    async def execute(
+        self,
+        nef_path: Optional[str] = None,
+        manifest_path: Optional[str] = None,
+        data: Optional[dict] = None,
+        network: Optional[str] = None,
+        private_key: Optional[str] = None,
+    ) -> ToolResult:
+        try:
+            network = network or self.network or "testnet"
+            nef_path = nef_path or self.nef_path
+            manifest_path = manifest_path or self.manifest_path
+            data = data if data is not None else self.data
+            private_key = private_key or self.private_key
+
+            if not nef_path:
+                return ToolResult(error="Missing nef_path parameter")
+            if not manifest_path:
+                return ToolResult(error="Missing manifest_path parameter")
+
+            try:
+                key = _resolve_private_key(private_key)
+            except ValueError as e:
+                return ToolResult(error=str(e))
+
+            try:
+                account = _create_neo3_account(key)
+            except Exception as e:
+                return ToolResult(error=f"Failed to create account from private key: {e}")
+
+            from neo3.api.wrappers import ChainFacade, GenericContract
+            from neo3.api.helpers.signing import sign_with_account
+            from neo3.network.payloads.verification import Signer, WitnessScope
+            from neo3.contracts.nef import NEF
+            from neo3.contracts.manifest import ContractManifest
+
+            # Load NEF file
+            try:
+                contract_nef = NEF.from_file(nef_path)
+            except Exception as e:
+                return ToolResult(error=f"Failed to load NEF file '{nef_path}': {e}")
+
+            # Load manifest
+            try:
+                contract_manifest = ContractManifest.from_file(manifest_path)
+            except Exception as e:
+                return ToolResult(error=f"Failed to load manifest file '{manifest_path}': {e}")
+
+            # Setup facade with GLOBAL scope (deployment needs broader permissions)
+            rpc_url = _get_rpc_url(network)
+            facade = ChainFacade(rpc_host=rpc_url)
+            facade.add_signer(
+                sign_with_account(account),
+                Signer(account.script_hash, WitnessScope.GLOBAL),
+            )
+
+            # Build deploy call
+            deploy_call = GenericContract.deploy(
+                nef=contract_nef,
+                manifest=contract_manifest,
+                data=data,
+            )
+
+            source_address = str(account.address)
+
+            # Execute deployment
+            receipt = await facade.invoke(deploy_call)
+            state_str = "HALT" if "HALT" in str(receipt.state) else str(receipt.state)
+            success = "HALT" in state_str
+
+            result = {
+                "tx_hash": str(receipt.tx_hash),
+                "success": success,
+                "state": state_str,
+                "deployer": source_address,
+                "gas_consumed": receipt.gas_consumed,
+                "included_in_block": receipt.included_in_block,
+                "network": network,
+            }
+
+            # Extract deployed contract hash from result
+            if success and receipt.result:
+                result["contract_hash"] = str(receipt.result)
+
+            if receipt.exception:
+                result["exception"] = receipt.exception
+
+            if not success:
+                return ToolResult(error=f"Deployment failed: {receipt.exception or state_str}", output=result)
+
+            return ToolResult(output=result)
+
+        except Exception as e:
+            err_msg = str(e) or repr(e)
+            logger.error(f"NeoDeployContractTool error: {err_msg}")
+            return ToolResult(error=f"Contract deployment failed: {err_msg}")

--- a/spoon_toolkits/crypto/neo/governance_action_tools.py
+++ b/spoon_toolkits/crypto/neo/governance_action_tools.py
@@ -1,0 +1,275 @@
+"""Neo governance action tools.
+
+Provides tools for governance operations on the Neo N3 blockchain:
+- Claiming unclaimed GAS
+- Voting for consensus node candidates
+"""
+
+import logging
+from typing import Optional
+
+from pydantic import Field
+
+from spoon_ai.tools.base import BaseTool, ToolResult
+from .transfer_tools import (
+    _get_rpc_url,
+    _resolve_private_key,
+    _create_neo3_account,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class NeoClaimGasTool(BaseTool):
+    """Claim unclaimed GAS on the Neo N3 blockchain.
+
+    On Neo N3, GAS is automatically distributed to NEO holders. Unclaimed GAS
+    is collected by transferring NEO to yourself, which triggers the GAS distribution.
+    This tool checks unclaimed GAS and triggers the claim if there is any.
+    """
+
+    name: str = "neo_claim_gas"
+    description: str = (
+        "Claim unclaimed GAS on the Neo N3 blockchain. "
+        "NEO holders earn GAS over time. This tool checks how much unclaimed GAS "
+        "the account has and triggers the claim by sending a self-transfer of NEO. "
+        "Returns the amount of GAS claimed and the transaction details."
+    )
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "network": {
+                "type": "string",
+                "enum": ["mainnet", "testnet"],
+                "description": "Neo network to use",
+                "default": "testnet",
+            },
+            "private_key": {
+                "type": "string",
+                "description": "Private key (WIF or hex). If omitted, uses NEO_PRIVATE_KEY env var.",
+            },
+        },
+        "required": [],
+    }
+
+    network: str = Field(default="testnet")
+    private_key: Optional[str] = Field(default=None)
+
+    async def execute(
+        self,
+        network: Optional[str] = None,
+        private_key: Optional[str] = None,
+    ) -> ToolResult:
+        try:
+            network = network or self.network or "testnet"
+            private_key = private_key or self.private_key
+
+            try:
+                key = _resolve_private_key(private_key)
+            except ValueError as e:
+                return ToolResult(error=str(e))
+
+            try:
+                account = _create_neo3_account(key)
+            except Exception as e:
+                return ToolResult(error=f"Failed to create account from private key: {e}")
+
+            from neo3.api.wrappers import ChainFacade, NeoToken
+            from neo3.api.helpers.signing import sign_with_account
+            from neo3.network.payloads.verification import Signer
+
+            rpc_url = _get_rpc_url(network)
+            facade = ChainFacade(rpc_host=rpc_url)
+            facade.add_signer(
+                sign_with_account(account),
+                Signer(account.script_hash),
+            )
+
+            neo_token = NeoToken()
+            source_address = str(account.address)
+
+            # Check unclaimed GAS
+            unclaimed_receipt = await facade.test_invoke(
+                neo_token.get_unclaimed_gas(account.script_hash)
+            )
+            unclaimed_raw = unclaimed_receipt.result
+            unclaimed_gas = unclaimed_raw / 10**8  # GAS has 8 decimals
+
+            if unclaimed_raw == 0:
+                return ToolResult(output={
+                    "address": source_address,
+                    "unclaimed_gas": 0.0,
+                    "message": "No unclaimed GAS to claim",
+                    "network": network,
+                })
+
+            # Check NEO balance for self-transfer
+            neo_balance_receipt = await facade.test_invoke(
+                neo_token.balance_of(account.script_hash)
+            )
+            neo_balance = neo_balance_receipt.result
+
+            if neo_balance == 0:
+                return ToolResult(output={
+                    "address": source_address,
+                    "unclaimed_gas": unclaimed_gas,
+                    "message": "Account holds 0 NEO; cannot trigger GAS claim via self-transfer",
+                    "network": network,
+                })
+
+            # Transfer NEO to self to trigger GAS claim
+            transfer_call = neo_token.transfer(
+                source=account.script_hash,
+                destination=source_address,
+                amount=neo_balance,
+            )
+
+            receipt = await facade.invoke(transfer_call)
+            state_str = "HALT" if "HALT" in str(receipt.state) else str(receipt.state)
+            success = "HALT" in state_str
+
+            result = {
+                "tx_hash": str(receipt.tx_hash),
+                "success": success,
+                "state": state_str,
+                "address": source_address,
+                "unclaimed_gas": unclaimed_gas,
+                "neo_balance": neo_balance,
+                "gas_consumed_by_tx": receipt.gas_consumed,
+                "included_in_block": receipt.included_in_block,
+                "network": network,
+            }
+
+            if receipt.exception:
+                result["exception"] = receipt.exception
+
+            if not success:
+                return ToolResult(error=f"GAS claim failed: {receipt.exception or state_str}", output=result)
+
+            return ToolResult(output=result)
+
+        except Exception as e:
+            err_msg = str(e) or repr(e)
+            logger.error(f"NeoClaimGasTool error: {err_msg}")
+            return ToolResult(error=f"GAS claim failed: {err_msg}")
+
+
+class NeoVoteTool(BaseTool):
+    """Vote for a consensus node candidate on the Neo N3 blockchain.
+
+    Cast a vote using your NEO holdings for a candidate to become a consensus node.
+    Your entire NEO balance counts as votes. You can change your vote at any time.
+    """
+
+    name: str = "neo_vote"
+    description: str = (
+        "Vote for a consensus node candidate on the Neo N3 blockchain. "
+        "Useful when you want to participate in Neo governance by voting for "
+        "a consensus node candidate. Your full NEO balance counts as votes. "
+        "Returns transaction hash and vote status."
+    )
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "network": {
+                "type": "string",
+                "enum": ["mainnet", "testnet"],
+                "description": "Neo network to use",
+                "default": "testnet",
+            },
+            "candidate_pubkey": {
+                "type": "string",
+                "description": "Public key of the candidate to vote for (hex-encoded, e.g. 02...)",
+            },
+            "private_key": {
+                "type": "string",
+                "description": "Voter private key (WIF or hex). If omitted, uses NEO_PRIVATE_KEY env var.",
+            },
+        },
+        "required": ["candidate_pubkey"],
+    }
+
+    network: str = Field(default="testnet")
+    candidate_pubkey: Optional[str] = Field(default=None)
+    private_key: Optional[str] = Field(default=None)
+
+    async def execute(
+        self,
+        candidate_pubkey: Optional[str] = None,
+        network: Optional[str] = None,
+        private_key: Optional[str] = None,
+    ) -> ToolResult:
+        try:
+            network = network or self.network or "testnet"
+            candidate_pubkey = candidate_pubkey or self.candidate_pubkey
+            private_key = private_key or self.private_key
+
+            if not candidate_pubkey:
+                return ToolResult(error="Missing candidate_pubkey parameter")
+
+            try:
+                key = _resolve_private_key(private_key)
+            except ValueError as e:
+                return ToolResult(error=str(e))
+
+            try:
+                account = _create_neo3_account(key)
+            except Exception as e:
+                return ToolResult(error=f"Failed to create account from private key: {e}")
+
+            from neo3.api.wrappers import ChainFacade, NeoToken
+            from neo3.api.helpers.signing import sign_with_account
+            from neo3.network.payloads.verification import Signer
+            from neo3.core import cryptography
+
+            rpc_url = _get_rpc_url(network)
+            facade = ChainFacade(rpc_host=rpc_url)
+            facade.add_signer(
+                sign_with_account(account),
+                Signer(account.script_hash),
+            )
+
+            neo_token = NeoToken()
+            source_address = str(account.address)
+
+            # Parse candidate public key
+            pubkey_hex = candidate_pubkey
+            if pubkey_hex.startswith("0x"):
+                pubkey_hex = pubkey_hex[2:]
+            candidate_key = cryptography.ECPoint.deserialize_from_bytes(
+                bytes.fromhex(pubkey_hex)
+            )
+
+            # Cast vote
+            vote_call = neo_token.candidate_vote(
+                voter=account.script_hash,
+                candidate=candidate_key,
+            )
+
+            receipt = await facade.invoke(vote_call)
+            state_str = "HALT" if "HALT" in str(receipt.state) else str(receipt.state)
+            success = "HALT" in state_str
+
+            result = {
+                "tx_hash": str(receipt.tx_hash),
+                "success": success,
+                "state": state_str,
+                "voter": source_address,
+                "candidate": candidate_pubkey,
+                "gas_consumed": receipt.gas_consumed,
+                "included_in_block": receipt.included_in_block,
+                "network": network,
+            }
+
+            if receipt.exception:
+                result["exception"] = receipt.exception
+
+            if not success:
+                return ToolResult(error=f"Vote failed: {receipt.exception or state_str}", output=result)
+
+            return ToolResult(output=result)
+
+        except Exception as e:
+            err_msg = str(e) or repr(e)
+            logger.error(f"NeoVoteTool error: {err_msg}")
+            return ToolResult(error=f"Vote failed: {err_msg}")

--- a/spoon_toolkits/crypto/neo/invoke_tools.py
+++ b/spoon_toolkits/crypto/neo/invoke_tools.py
@@ -1,0 +1,684 @@
+"""Neo smart contract invocation tools.
+
+Provides tools for invoking smart contract methods on the Neo N3 blockchain,
+both state-changing (costs GAS) and read-only (free) invocations.
+Uses neo-mamba's ChainFacade for transaction lifecycle management.
+"""
+
+import os
+import json
+import logging
+from typing import Optional, List, Any
+
+from pydantic import Field
+
+from spoon_ai.tools.base import BaseTool, ToolResult
+from .transfer_tools import (
+    _get_rpc_url,
+    _resolve_private_key,
+    _create_neo3_account,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_contract_args(args: Optional[List[Any]]) -> Optional[list]:
+    """Parse contract arguments into neo3-compatible format.
+
+    Supports basic types: int, str, bool, bytes (hex-encoded), and UInt160 (0x-prefixed hash).
+    Each arg can be a raw value or a dict with {"type": ..., "value": ...} for explicit typing.
+
+    Supported explicit types:
+        - "Integer" / "int": integer value
+        - "String" / "str": string value
+        - "Boolean" / "bool": boolean value
+        - "ByteArray" / "bytes": hex-encoded byte array
+        - "Hash160" / "address": Neo address or 0x-prefixed script hash → UInt160
+        - "Hash256": 0x-prefixed 256-bit hash → UInt256
+        - "Array": list of nested args
+
+    Returns:
+        List of parsed arguments, or None if args is None/empty.
+    """
+    if not args:
+        return None
+
+    from neo3.core import types
+    from neo3.wallet import utils as walletutils
+
+    parsed = []
+    for arg in args:
+        if arg is None:
+            parsed.append(None)
+            continue
+        if isinstance(arg, dict) and "type" in arg and "value" in arg:
+            arg_type = arg["type"].lower()
+            value = arg["value"]
+
+            if arg_type in ("integer", "int"):
+                parsed.append(int(value))
+            elif arg_type in ("string", "str"):
+                parsed.append(str(value))
+            elif arg_type in ("boolean", "bool"):
+                parsed.append(bool(value))
+            elif arg_type in ("bytearray", "bytes"):
+                if isinstance(value, str):
+                    parsed.append(bytes.fromhex(value.replace("0x", "")))
+                else:
+                    parsed.append(bytes(value))
+            elif arg_type in ("hash160", "address"):
+                value_str = str(value)
+                if value_str.startswith("0x"):
+                    parsed.append(types.UInt160.from_string(value_str))
+                else:
+                    # Assume Neo address
+                    script_hash = walletutils.address_to_script_hash(value_str)
+                    parsed.append(script_hash)
+            elif arg_type == "hash256":
+                parsed.append(types.UInt256.from_string(str(value)))
+            elif arg_type == "array":
+                parsed.append(_parse_contract_args(value))
+            else:
+                # Unknown type, pass as-is
+                parsed.append(value)
+        elif isinstance(arg, bool):
+            parsed.append(arg)
+        elif isinstance(arg, int):
+            parsed.append(arg)
+        elif isinstance(arg, str):
+            # Heuristic: if it looks like a script hash, convert to UInt160
+            if arg.startswith("0x") and len(arg) == 42:
+                parsed.append(types.UInt160.from_string(arg))
+            else:
+                parsed.append(arg)
+        else:
+            parsed.append(arg)
+
+    return parsed
+
+
+class NeoInvokeContractTool(BaseTool):
+    """Invoke a smart contract method on the Neo N3 blockchain (state-changing, costs GAS).
+
+    Builds, signs, and broadcasts a contract invocation transaction.
+    """
+
+    name: str = "neo_invoke_contract"
+    description: str = (
+        "Invoke a smart contract method on the Neo N3 blockchain. "
+        "This is a state-changing operation that costs GAS. "
+        "Useful when you need to call a contract method that modifies on-chain state. "
+        "Returns transaction hash, execution state, gas consumed, and notifications."
+    )
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "network": {
+                "type": "string",
+                "enum": ["mainnet", "testnet"],
+                "description": "Neo network to use",
+                "default": "testnet",
+            },
+            "contract_hash": {
+                "type": "string",
+                "description": "Contract script hash (0x-prefixed, e.g. 0xd2a4cff31913016155e38e474a2c06d08be276cf)",
+            },
+            "method": {
+                "type": "string",
+                "description": "Contract method name to invoke",
+            },
+            "args": {
+                "type": "array",
+                "description": (
+                    "Arguments for the method. Each arg can be a raw value (int, string, bool) "
+                    "or a dict with {\"type\": \"...\", \"value\": \"...\"} for explicit typing. "
+                    "Supported types: Integer, String, Boolean, ByteArray, Hash160, Hash256, Array."
+                ),
+                "items": {},
+            },
+            "private_key": {
+                "type": "string",
+                "description": "Sender private key (WIF or hex). If omitted, uses NEO_PRIVATE_KEY env var.",
+            },
+            "wait_for_receipt": {
+                "type": "boolean",
+                "description": "Whether to wait for the transaction to be included in a block. Default true.",
+                "default": True,
+            },
+        },
+        "required": ["contract_hash", "method"],
+    }
+
+    network: str = Field(default="testnet")
+    contract_hash: Optional[str] = Field(default=None)
+    method: Optional[str] = Field(default=None)
+    args: Optional[List[Any]] = Field(default=None)
+    private_key: Optional[str] = Field(default=None)
+    wait_for_receipt: bool = Field(default=True)
+
+    async def execute(
+        self,
+        contract_hash: Optional[str] = None,
+        method: Optional[str] = None,
+        args: Optional[List[Any]] = None,
+        network: Optional[str] = None,
+        private_key: Optional[str] = None,
+        wait_for_receipt: Optional[bool] = None,
+    ) -> ToolResult:
+        try:
+            # Resolve parameters
+            network = network or self.network or "testnet"
+            contract_hash = contract_hash or self.contract_hash
+            method = method or self.method
+            args = args if args is not None else self.args
+            private_key = private_key or self.private_key
+            wait_for_receipt = wait_for_receipt if wait_for_receipt is not None else self.wait_for_receipt
+
+            if not contract_hash:
+                return ToolResult(error="Missing contract_hash parameter")
+            if not method:
+                return ToolResult(error="Missing method parameter")
+
+            # Resolve private key and create account
+            try:
+                key = _resolve_private_key(private_key)
+            except ValueError as e:
+                return ToolResult(error=str(e))
+
+            try:
+                account = _create_neo3_account(key)
+            except Exception as e:
+                return ToolResult(error=f"Failed to create account from private key: {e}")
+
+            # Lazy imports
+            from neo3.api.wrappers import ChainFacade, GenericContract
+            from neo3.api.helpers.signing import sign_with_account
+            from neo3.network.payloads.verification import Signer
+            from neo3.core import types
+
+            # Setup facade
+            rpc_url = _get_rpc_url(network)
+            facade = ChainFacade(rpc_host=rpc_url)
+            facade.add_signer(
+                sign_with_account(account),
+                Signer(account.script_hash),
+            )
+
+            # Build contract call
+            if not contract_hash.startswith("0x"):
+                contract_hash = f"0x{contract_hash}"
+            contract = GenericContract(types.UInt160.from_string(contract_hash))
+
+            parsed_args = _parse_contract_args(args)
+            call = contract.call_function(method, parsed_args)
+
+            # Execute
+            source_address = str(account.address)
+
+            if wait_for_receipt:
+                receipt = await facade.invoke(call)
+                state_str = "HALT" if "HALT" in str(receipt.state) else str(receipt.state)
+                success = "HALT" in state_str
+
+                # Format notifications
+                notifications = []
+                for n in receipt.notifications:
+                    notifications.append({
+                        "contract": str(n.contract),
+                        "event_name": n.event_name,
+                        "state": str(n.state),
+                    })
+
+                result = {
+                    "tx_hash": str(receipt.tx_hash),
+                    "success": success,
+                    "state": state_str,
+                    "gas_consumed": receipt.gas_consumed,
+                    "included_in_block": receipt.included_in_block,
+                    "confirmations": receipt.confirmations,
+                    "from": source_address,
+                    "contract": contract_hash,
+                    "method": method,
+                    "notifications": notifications,
+                    "network": network,
+                }
+
+                if receipt.exception:
+                    result["exception"] = receipt.exception
+
+                if not success:
+                    return ToolResult(error=f"Contract invocation failed: {receipt.exception or state_str}", output=result)
+
+                return ToolResult(output=result)
+            else:
+                tx_hash = await facade.invoke_fast(call)
+                return ToolResult(output={
+                    "tx_hash": str(tx_hash),
+                    "status": "submitted",
+                    "from": source_address,
+                    "contract": contract_hash,
+                    "method": method,
+                    "network": network,
+                })
+
+        except Exception as e:
+            err_msg = str(e) or repr(e)
+            logger.error(f"NeoInvokeContractTool error: {err_msg}")
+            return ToolResult(error=f"Contract invocation failed: {err_msg}")
+
+
+class NeoTestInvokeTool(BaseTool):
+    """Test invoke a smart contract method on Neo N3 (read-only, no GAS cost).
+
+    Executes the contract method without persisting state changes.
+    Useful for querying contract state or estimating gas before a real invocation.
+    """
+
+    name: str = "neo_test_invoke"
+    description: str = (
+        "Test invoke a smart contract method on the Neo N3 blockchain (read-only, no GAS cost). "
+        "Useful when you need to query contract state, estimate gas cost, or preview "
+        "the result of a contract method before actually sending a transaction. "
+        "Returns execution result, gas estimate, and stack output."
+    )
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "network": {
+                "type": "string",
+                "enum": ["mainnet", "testnet"],
+                "description": "Neo network to use",
+                "default": "testnet",
+            },
+            "contract_hash": {
+                "type": "string",
+                "description": "Contract script hash (0x-prefixed)",
+            },
+            "method": {
+                "type": "string",
+                "description": "Contract method name to invoke",
+            },
+            "args": {
+                "type": "array",
+                "description": (
+                    "Arguments for the method. Each arg can be a raw value (int, string, bool) "
+                    "or a dict with {\"type\": \"...\", \"value\": \"...\"} for explicit typing."
+                ),
+                "items": {},
+            },
+            "signer_address": {
+                "type": "string",
+                "description": "Optional signer address for authorization context (Neo address or 0x-prefixed script hash). Some methods require a signer to return correct results.",
+            },
+        },
+        "required": ["contract_hash", "method"],
+    }
+
+    network: str = Field(default="testnet")
+    contract_hash: Optional[str] = Field(default=None)
+    method: Optional[str] = Field(default=None)
+    args: Optional[List[Any]] = Field(default=None)
+    signer_address: Optional[str] = Field(default=None)
+
+    async def execute(
+        self,
+        contract_hash: Optional[str] = None,
+        method: Optional[str] = None,
+        args: Optional[List[Any]] = None,
+        network: Optional[str] = None,
+        signer_address: Optional[str] = None,
+    ) -> ToolResult:
+        try:
+            # Resolve parameters
+            network = network or self.network or "testnet"
+            contract_hash = contract_hash or self.contract_hash
+            method = method or self.method
+            args = args if args is not None else self.args
+            signer_address = signer_address or self.signer_address
+
+            if not contract_hash:
+                return ToolResult(error="Missing contract_hash parameter")
+            if not method:
+                return ToolResult(error="Missing method parameter")
+
+            # Lazy imports
+            from neo3.api.wrappers import ChainFacade, GenericContract
+            from neo3.network.payloads.verification import Signer
+            from neo3.core import types
+            from neo3.wallet import utils as walletutils
+
+            # Setup facade
+            rpc_url = _get_rpc_url(network)
+            facade = ChainFacade(rpc_host=rpc_url)
+
+            # Add test signer if provided
+            if signer_address:
+                if signer_address.startswith("0x"):
+                    signer_hash = types.UInt160.from_string(signer_address)
+                else:
+                    signer_hash = walletutils.address_to_script_hash(signer_address)
+                facade.add_test_signer(Signer(signer_hash))
+
+            # Build contract call
+            if not contract_hash.startswith("0x"):
+                contract_hash = f"0x{contract_hash}"
+            contract = GenericContract(types.UInt160.from_string(contract_hash))
+
+            parsed_args = _parse_contract_args(args)
+            call = contract.call_function(method, parsed_args)
+
+            # Test invoke
+            receipt = await facade.test_invoke(call)
+            state_str = "HALT" if "HALT" in str(receipt.state) else str(receipt.state)
+            success = "HALT" in state_str
+
+            # Format stack output
+            stack_output = []
+            if hasattr(receipt.result, 'stack'):
+                for item in receipt.result.stack:
+                    stack_output.append({
+                        "type": str(item.type) if hasattr(item, 'type') else type(item).__name__,
+                        "value": str(item.value) if hasattr(item, 'value') else str(item),
+                    })
+            else:
+                stack_output.append({"value": str(receipt.result)})
+
+            # Format notifications
+            notifications = []
+            for n in receipt.notifications:
+                notifications.append({
+                    "contract": str(n.contract),
+                    "event_name": n.event_name,
+                    "state": str(n.state),
+                })
+
+            result = {
+                "success": success,
+                "state": state_str,
+                "gas_consumed": receipt.gas_consumed,
+                "stack": stack_output,
+                "notifications": notifications,
+                "contract": contract_hash,
+                "method": method,
+                "network": network,
+            }
+
+            if receipt.exception:
+                result["exception"] = receipt.exception
+
+            if not success:
+                return ToolResult(error=f"Test invocation faulted: {receipt.exception or state_str}", output=result)
+
+            return ToolResult(output=result)
+
+        except Exception as e:
+            err_msg = str(e) or repr(e)
+            logger.error(f"NeoTestInvokeTool error: {err_msg}")
+            return ToolResult(error=f"Test invocation failed: {err_msg}")
+
+
+class NeoBatchInvokeTool(BaseTool):
+    """Invoke multiple smart contract methods in a single transaction on Neo N3.
+
+    Batches multiple contract calls into one transaction, reducing overall GAS cost
+    and ensuring atomicity (all calls succeed or all fail).
+    """
+
+    name: str = "neo_batch_invoke"
+    description: str = (
+        "Invoke multiple smart contract methods in a single transaction on Neo N3. "
+        "Useful when you need to execute several contract calls atomically and save GAS. "
+        "All calls are concatenated into one transaction; if any fails, all revert. "
+        "Returns transaction hash, execution state, and per-call results."
+    )
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "network": {
+                "type": "string",
+                "enum": ["mainnet", "testnet"],
+                "description": "Neo network to use",
+                "default": "testnet",
+            },
+            "calls": {
+                "type": "array",
+                "description": (
+                    "List of contract calls. Each call is an object with: "
+                    "'contract_hash' (0x-prefixed), 'method' (string), and optional 'args' (array)."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "contract_hash": {"type": "string"},
+                        "method": {"type": "string"},
+                        "args": {"type": "array", "items": {}},
+                    },
+                    "required": ["contract_hash", "method"],
+                },
+            },
+            "private_key": {
+                "type": "string",
+                "description": "Sender private key (WIF or hex). If omitted, uses NEO_PRIVATE_KEY env var.",
+            },
+        },
+        "required": ["calls"],
+    }
+
+    network: str = Field(default="testnet")
+    calls: Optional[List[dict]] = Field(default=None)
+    private_key: Optional[str] = Field(default=None)
+
+    async def execute(
+        self,
+        calls: Optional[List[dict]] = None,
+        network: Optional[str] = None,
+        private_key: Optional[str] = None,
+    ) -> ToolResult:
+        try:
+            network = network or self.network or "testnet"
+            calls = calls or self.calls
+            private_key = private_key or self.private_key
+
+            if not calls or len(calls) == 0:
+                return ToolResult(error="Missing or empty calls parameter")
+
+            try:
+                key = _resolve_private_key(private_key)
+            except ValueError as e:
+                return ToolResult(error=str(e))
+
+            try:
+                account = _create_neo3_account(key)
+            except Exception as e:
+                return ToolResult(error=f"Failed to create account from private key: {e}")
+
+            from neo3.api.wrappers import ChainFacade, GenericContract
+            from neo3.api.helpers.signing import sign_with_account
+            from neo3.network.payloads.verification import Signer
+            from neo3.core import types
+
+            rpc_url = _get_rpc_url(network)
+            facade = ChainFacade(rpc_host=rpc_url)
+            facade.add_signer(
+                sign_with_account(account),
+                Signer(account.script_hash),
+            )
+
+            # Build all contract calls
+            contract_calls = []
+            for i, call_def in enumerate(calls):
+                contract_hash = call_def.get("contract_hash", "")
+                method = call_def.get("method", "")
+                args = call_def.get("args")
+
+                if not contract_hash or not method:
+                    return ToolResult(error=f"Call #{i}: missing contract_hash or method")
+
+                if not contract_hash.startswith("0x"):
+                    contract_hash = f"0x{contract_hash}"
+                contract = GenericContract(types.UInt160.from_string(contract_hash))
+                parsed_args = _parse_contract_args(args)
+                contract_calls.append(contract.call_function(method, parsed_args))
+
+            source_address = str(account.address)
+
+            # Execute batch
+            receipt = await facade.invoke_multi(contract_calls)
+            state_str = "HALT" if "HALT" in str(receipt.state) else str(receipt.state)
+            success = "HALT" in state_str
+
+            # Format per-call results
+            call_results = []
+            if isinstance(receipt.result, (list, tuple)):
+                for i, r in enumerate(receipt.result):
+                    call_results.append({
+                        "index": i,
+                        "result": str(r),
+                    })
+
+            notifications = []
+            for n in receipt.notifications:
+                notifications.append({
+                    "contract": str(n.contract),
+                    "event_name": n.event_name,
+                    "state": str(n.state),
+                })
+
+            result = {
+                "tx_hash": str(receipt.tx_hash),
+                "success": success,
+                "state": state_str,
+                "gas_consumed": receipt.gas_consumed,
+                "included_in_block": receipt.included_in_block,
+                "from": source_address,
+                "calls_count": len(calls),
+                "call_results": call_results,
+                "notifications": notifications,
+                "network": network,
+            }
+
+            if receipt.exception:
+                result["exception"] = receipt.exception
+
+            if not success:
+                return ToolResult(error=f"Batch invocation failed: {receipt.exception or state_str}", output=result)
+
+            return ToolResult(output=result)
+
+        except Exception as e:
+            err_msg = str(e) or repr(e)
+            logger.error(f"NeoBatchInvokeTool error: {err_msg}")
+            return ToolResult(error=f"Batch invocation failed: {err_msg}")
+
+
+class NeoEstimateGasTool(BaseTool):
+    """Estimate GAS cost for a smart contract invocation on Neo N3.
+
+    Simulates the contract call without broadcasting and returns the estimated
+    system fee (GAS consumed by the VM). Useful for previewing costs.
+    """
+
+    name: str = "neo_estimate_gas"
+    description: str = (
+        "Estimate GAS cost for a smart contract invocation on Neo N3. "
+        "Useful when you need to know how much GAS a contract call will cost "
+        "before actually sending the transaction. Does not broadcast anything. "
+        "Returns estimated GAS in both raw (integer) and human-readable formats."
+    )
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "network": {
+                "type": "string",
+                "enum": ["mainnet", "testnet"],
+                "description": "Neo network to use",
+                "default": "testnet",
+            },
+            "contract_hash": {
+                "type": "string",
+                "description": "Contract script hash (0x-prefixed)",
+            },
+            "method": {
+                "type": "string",
+                "description": "Contract method name",
+            },
+            "args": {
+                "type": "array",
+                "description": "Arguments for the method",
+                "items": {},
+            },
+            "signer_address": {
+                "type": "string",
+                "description": "Optional signer address for fee estimation context (Neo address or 0x-prefixed script hash).",
+            },
+        },
+        "required": ["contract_hash", "method"],
+    }
+
+    network: str = Field(default="testnet")
+    contract_hash: Optional[str] = Field(default=None)
+    method: Optional[str] = Field(default=None)
+    args: Optional[List[Any]] = Field(default=None)
+    signer_address: Optional[str] = Field(default=None)
+
+    async def execute(
+        self,
+        contract_hash: Optional[str] = None,
+        method: Optional[str] = None,
+        args: Optional[List[Any]] = None,
+        network: Optional[str] = None,
+        signer_address: Optional[str] = None,
+    ) -> ToolResult:
+        try:
+            network = network or self.network or "testnet"
+            contract_hash = contract_hash or self.contract_hash
+            method = method or self.method
+            args = args if args is not None else self.args
+            signer_address = signer_address or self.signer_address
+
+            if not contract_hash:
+                return ToolResult(error="Missing contract_hash parameter")
+            if not method:
+                return ToolResult(error="Missing method parameter")
+
+            from neo3.api.wrappers import ChainFacade, GenericContract
+            from neo3.network.payloads.verification import Signer
+            from neo3.core import types
+            from neo3.wallet import utils as walletutils
+
+            rpc_url = _get_rpc_url(network)
+            facade = ChainFacade(rpc_host=rpc_url)
+
+            # Build signers list for estimation
+            signers = None
+            if signer_address:
+                if signer_address.startswith("0x"):
+                    signer_hash = types.UInt160.from_string(signer_address)
+                else:
+                    signer_hash = walletutils.address_to_script_hash(signer_address)
+                signers = [Signer(signer_hash)]
+
+            # Build contract call
+            if not contract_hash.startswith("0x"):
+                contract_hash = f"0x{contract_hash}"
+            contract = GenericContract(types.UInt160.from_string(contract_hash))
+
+            parsed_args = _parse_contract_args(args)
+            call = contract.call_function(method, parsed_args)
+
+            # Estimate gas
+            gas_raw = await facade.estimate_gas(call, signers=signers)
+            gas_human = gas_raw / 10**8  # GAS has 8 decimals
+
+            return ToolResult(output={
+                "contract": contract_hash,
+                "method": method,
+                "estimated_gas": gas_human,
+                "estimated_gas_raw": gas_raw,
+                "network": network,
+            })
+
+        except Exception as e:
+            err_msg = str(e) or repr(e)
+            logger.error(f"NeoEstimateGasTool error: {err_msg}")
+            return ToolResult(error=f"Gas estimation failed: {err_msg}")

--- a/spoon_toolkits/crypto/neo/multisig_tools.py
+++ b/spoon_toolkits/crypto/neo/multisig_tools.py
@@ -1,0 +1,108 @@
+"""Neo multi-signature account tools.
+
+Create and manage multi-signature accounts on the Neo N3 blockchain.
+Multi-sig accounts require M-of-N signatures to authorize transactions.
+"""
+
+import logging
+from typing import Optional, List
+
+from pydantic import Field
+
+from spoon_ai.tools.base import BaseTool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+class NeoMultiSigCreateTool(BaseTool):
+    """Create a multi-signature account on the Neo N3 blockchain.
+
+    Generates an M-of-N multi-sig account from a list of public keys.
+    The resulting account requires at least M signatures from the N participants
+    to authorize any transaction.
+    """
+
+    name: str = "neo_create_multisig"
+    description: str = (
+        "Create a multi-signature account on the Neo N3 blockchain. "
+        "Useful when you need to set up a shared account that requires multiple "
+        "signatures (M-of-N) to authorize transactions. "
+        "Returns the multi-sig address, script hash, and verification script."
+    )
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "public_keys": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "List of public keys (hex-encoded, e.g. ['02abc...', '03def...']). These are the N participants.",
+            },
+            "threshold": {
+                "type": "integer",
+                "description": "Minimum number of signatures required (M). Must be between 1 and the number of public keys.",
+            },
+        },
+        "required": ["public_keys", "threshold"],
+    }
+
+    public_keys: Optional[List[str]] = Field(default=None)
+    threshold: Optional[int] = Field(default=None)
+
+    async def execute(
+        self,
+        public_keys: Optional[List[str]] = None,
+        threshold: Optional[int] = None,
+    ) -> ToolResult:
+        try:
+            public_keys = public_keys or self.public_keys
+            threshold = threshold or self.threshold
+
+            if not public_keys:
+                return ToolResult(error="Missing public_keys parameter")
+            if not threshold:
+                return ToolResult(error="Missing threshold parameter")
+            if threshold < 1:
+                return ToolResult(error="Threshold must be at least 1")
+            if threshold > len(public_keys):
+                return ToolResult(error=f"Threshold ({threshold}) cannot exceed number of public keys ({len(public_keys)})")
+
+            from neo3.core import cryptography, utils as coreutils
+            from neo3.contracts import utils as contractutils
+            from neo3.wallet import utils as walletutils
+
+            # Parse public keys
+            ec_points = []
+            for pk_hex in public_keys:
+                pk = pk_hex
+                if pk.startswith("0x"):
+                    pk = pk[2:]
+                try:
+                    ec_point = cryptography.ECPoint.deserialize_from_bytes(
+                        bytes.fromhex(pk)
+                    )
+                    ec_points.append(ec_point)
+                except Exception as e:
+                    return ToolResult(error=f"Invalid public key '{pk_hex}': {e}")
+
+            # Create multi-sig redeem script
+            multisig_script = contractutils.create_multisig_redeemscript(
+                threshold, ec_points
+            )
+
+            # Derive script hash and address
+            script_hash = coreutils.to_script_hash(multisig_script)
+            address = walletutils.script_hash_to_address(script_hash)
+
+            return ToolResult(output={
+                "address": str(address),
+                "script_hash": f"0x{script_hash}",
+                "threshold": threshold,
+                "participants": len(public_keys),
+                "public_keys": public_keys,
+                "verification_script": multisig_script.hex(),
+            })
+
+        except Exception as e:
+            err_msg = str(e) or repr(e)
+            logger.error(f"NeoMultiSigCreateTool error: {err_msg}")
+            return ToolResult(error=f"Multi-sig creation failed: {err_msg}")

--- a/spoon_toolkits/crypto/neo/storage_tools.py
+++ b/spoon_toolkits/crypto/neo/storage_tools.py
@@ -1,0 +1,119 @@
+"""Neo smart contract storage query tool.
+
+Query smart contract storage on the Neo N3 blockchain using RPC node.
+Supports prefix-based filtering and pagination for large storage sets.
+"""
+
+import logging
+from typing import Optional
+
+from pydantic import Field
+
+from spoon_ai.tools.base import BaseTool, ToolResult
+from .transfer_tools import _get_rpc_url
+
+logger = logging.getLogger(__name__)
+
+
+class NeoContractStorageTool(BaseTool):
+    """Query smart contract storage on the Neo N3 blockchain.
+
+    Read storage entries from a deployed smart contract. Supports prefix-based
+    filtering to narrow results and handles pagination for large storage sets.
+    Useful for inspecting contract state, token balances, or any on-chain data.
+    """
+
+    name: str = "neo_contract_storage"
+    description: str = (
+        "Query smart contract storage on the Neo N3 blockchain. "
+        "Useful when you need to read raw storage entries from a deployed contract, "
+        "inspect contract state, or look up specific storage keys. "
+        "Supports prefix-based filtering. Returns key-value pairs in hex format."
+    )
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "network": {
+                "type": "string",
+                "enum": ["mainnet", "testnet"],
+                "description": "Neo network to use",
+                "default": "testnet",
+            },
+            "contract_hash": {
+                "type": "string",
+                "description": "Contract script hash (0x-prefixed)",
+            },
+            "prefix": {
+                "type": "string",
+                "description": "Storage key prefix to filter results (hex-encoded). If omitted, returns all storage entries.",
+                "default": "",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of entries to return. Default 100.",
+                "default": 100,
+            },
+        },
+        "required": ["contract_hash"],
+    }
+
+    network: str = Field(default="testnet")
+    contract_hash: Optional[str] = Field(default=None)
+    prefix: str = Field(default="")
+    limit: int = Field(default=100)
+
+    async def execute(
+        self,
+        contract_hash: Optional[str] = None,
+        prefix: Optional[str] = None,
+        limit: Optional[int] = None,
+        network: Optional[str] = None,
+    ) -> ToolResult:
+        try:
+            network = network or self.network or "testnet"
+            contract_hash = contract_hash or self.contract_hash
+            prefix = prefix if prefix is not None else self.prefix
+            limit = limit or self.limit
+
+            if not contract_hash:
+                return ToolResult(error="Missing contract_hash parameter")
+
+            from neo3.api import noderpc
+            from neo3.core import types
+
+            if not contract_hash.startswith("0x"):
+                contract_hash = f"0x{contract_hash}"
+
+            rpc_url = _get_rpc_url(network)
+
+            # Convert prefix from hex string to bytes
+            prefix_bytes = bytes.fromhex(prefix) if prefix else b""
+
+            entries = []
+            async with noderpc.NeoRpcClient(rpc_url) as client:
+                count = 0
+                async for key, value in client.find_states(
+                    types.UInt160.from_string(contract_hash),
+                    prefix_bytes,
+                ):
+                    entries.append({
+                        "key": key.hex() if isinstance(key, bytes) else str(key),
+                        "value": value.hex() if isinstance(value, bytes) else str(value),
+                    })
+                    count += 1
+                    if count >= limit:
+                        break
+
+            return ToolResult(output={
+                "contract": contract_hash,
+                "prefix": prefix,
+                "entries": entries,
+                "count": len(entries),
+                "truncated": len(entries) >= limit,
+                "network": network,
+            })
+
+        except Exception as e:
+            err_msg = str(e) or repr(e)
+            logger.error(f"NeoContractStorageTool error: {err_msg}")
+            return ToolResult(error=f"Storage query failed: {err_msg}")

--- a/spoon_toolkits/crypto/neo/transfer_tools.py
+++ b/spoon_toolkits/crypto/neo/transfer_tools.py
@@ -1,0 +1,427 @@
+"""Neo token transfer tools.
+
+Supports transferring NEP-17 tokens (NEO, GAS, custom) and NEP-11 NFTs
+on the Neo N3 blockchain. Uses neo-mamba's ChainFacade for transaction
+building, signing, fee calculation, and broadcasting.
+"""
+
+import os
+import logging
+from typing import Optional
+
+from pydantic import Field
+
+from spoon_ai.tools.base import BaseTool, ToolResult
+from .signers import (
+    ENV_PRIVATE_KEY,
+    _is_encrypted,
+    _get_private_key_from_vault,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# RPC URLs (same convention as neo_provider.py)
+DEFAULT_MAINNET_RPC = "https://mainmagnet.ngd.network:443"
+DEFAULT_TESTNET_RPC = "https://testmagnet.ngd.network:443"
+
+# Well-known token identifiers
+_TOKEN_ALIASES = {"NEO", "GAS"}
+
+
+def _get_rpc_url(network: str) -> str:
+    """Resolve RPC URL from network name and environment variables."""
+    if network == "mainnet":
+        return os.getenv("NEO_MAINNET_RPC", DEFAULT_MAINNET_RPC)
+    return os.getenv("NEO_TESTNET_RPC", DEFAULT_TESTNET_RPC)
+
+
+def _resolve_private_key(private_key: Optional[str] = None) -> str:
+    """Resolve private key from parameter, env var, or vault.
+
+    Priority: explicit param → plain env → vault-decrypted env.
+
+    Returns:
+        Private key string (WIF or hex).
+
+    Raises:
+        ValueError: if no private key can be resolved.
+    """
+    if private_key:
+        return private_key.strip()
+
+    env_key = os.getenv(ENV_PRIVATE_KEY)
+    if env_key and not _is_encrypted(env_key):
+        return env_key.strip()
+
+    vault_key = _get_private_key_from_vault()
+    if vault_key:
+        return vault_key.strip()
+
+    raise ValueError(
+        f"No private key available. Provide private_key parameter or set {ENV_PRIVATE_KEY} env var."
+    )
+
+
+def _create_neo3_account(private_key: str):
+    """Create a neo3 Account from a WIF or hex private key.
+
+    Returns:
+        neo3.wallet.account.Account instance.
+    """
+    from neo3.wallet.account import Account
+
+    # Try WIF first
+    try:
+        return Account.from_wif(private_key)
+    except Exception:
+        pass
+
+    # Try hex private key
+    key_hex = private_key
+    if key_hex.startswith("0x"):
+        key_hex = key_hex[2:]
+    key_bytes = bytes.fromhex(key_hex)
+    return Account.from_private_key(key_bytes)
+
+
+class NeoTransferTool(BaseTool):
+    """Transfer NEP-17 tokens (NEO, GAS, or custom tokens) on the Neo N3 blockchain.
+
+    Builds, signs, and broadcasts a transfer transaction using neo-mamba's ChainFacade.
+    Supports both local private key and environment-variable-based signing.
+    """
+
+    name: str = "neo_transfer"
+    description: str = (
+        "Transfer NEP-17 tokens (NEO, GAS, or custom tokens) on the Neo N3 blockchain. "
+        "Useful when you need to send NEO, GAS, or any NEP-17 token to another address. "
+        "Returns transaction hash, execution state, gas consumed, and block information."
+    )
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "network": {
+                "type": "string",
+                "enum": ["mainnet", "testnet"],
+                "description": "Neo network to use",
+                "default": "testnet",
+            },
+            "to_address": {
+                "type": "string",
+                "description": "Recipient Neo address (Base58 format, e.g. NXV2zshzasps7nqz2kcrv69zWhksVSG87D)",
+            },
+            "amount": {
+                "type": "string",
+                "description": "Amount to transfer in human-readable units (e.g. '10', '0.5')",
+            },
+            "token": {
+                "type": "string",
+                "description": "Token to transfer: 'NEO', 'GAS', or a contract hash (0x-prefixed). Defaults to GAS.",
+                "default": "GAS",
+            },
+            "private_key": {
+                "type": "string",
+                "description": "Sender private key (WIF or hex). If omitted, uses NEO_PRIVATE_KEY env var.",
+            },
+            "wait_for_receipt": {
+                "type": "boolean",
+                "description": "Whether to wait for the transaction to be included in a block. Default true.",
+                "default": True,
+            },
+        },
+        "required": ["to_address", "amount"],
+    }
+
+    network: str = Field(default="testnet")
+    to_address: Optional[str] = Field(default=None)
+    amount: Optional[str] = Field(default=None)
+    token: str = Field(default="GAS")
+    private_key: Optional[str] = Field(default=None)
+    wait_for_receipt: bool = Field(default=True)
+
+    async def execute(
+        self,
+        to_address: Optional[str] = None,
+        amount: Optional[str] = None,
+        token: Optional[str] = None,
+        network: Optional[str] = None,
+        private_key: Optional[str] = None,
+        wait_for_receipt: Optional[bool] = None,
+    ) -> ToolResult:
+        try:
+            # Resolve parameters
+            network = network or self.network or "testnet"
+            to_address = to_address or self.to_address
+            amount = amount or self.amount
+            token = token or self.token or "GAS"
+            private_key = private_key or self.private_key
+            wait_for_receipt = wait_for_receipt if wait_for_receipt is not None else self.wait_for_receipt
+
+            if not to_address:
+                return ToolResult(error="Missing to_address parameter")
+            if not amount:
+                return ToolResult(error="Missing amount parameter")
+
+            try:
+                amount_float = float(amount)
+            except ValueError:
+                return ToolResult(error=f"Invalid amount: {amount}")
+
+            if amount_float <= 0:
+                return ToolResult(error="Amount must be positive")
+
+            # Resolve private key and create account
+            try:
+                key = _resolve_private_key(private_key)
+            except ValueError as e:
+                return ToolResult(error=str(e))
+
+            try:
+                account = _create_neo3_account(key)
+            except Exception as e:
+                return ToolResult(error=f"Failed to create account from private key: {e}")
+
+            # Lazy imports for neo3
+            from neo3.api.wrappers import (
+                ChainFacade,
+                NEP17Contract,
+                NeoToken,
+                GasToken,
+            )
+            from neo3.api.helpers.signing import sign_with_account
+            from neo3.network.payloads.verification import Signer
+            from neo3.core import types
+
+            # Setup facade
+            rpc_url = _get_rpc_url(network)
+            facade = ChainFacade(rpc_host=rpc_url)
+            facade.add_signer(
+                sign_with_account(account),
+                Signer(account.script_hash),
+            )
+
+            # Resolve token contract
+            token_upper = token.upper()
+            if token_upper == "NEO":
+                token_contract = NeoToken()
+                decimals = 0
+            elif token_upper == "GAS":
+                token_contract = GasToken()
+                decimals = 8
+            else:
+                # Custom NEP-17 token by contract hash
+                contract_hash = token
+                if not contract_hash.startswith("0x"):
+                    contract_hash = f"0x{contract_hash}"
+                token_contract = NEP17Contract(types.UInt160.from_string(contract_hash))
+                # Query decimals from contract
+                decimals_receipt = await facade.test_invoke(token_contract.decimals())
+                decimals = decimals_receipt.result
+
+            # For NEO (0 decimals), amount must be integer
+            if decimals == 0:
+                if amount_float != int(amount_float):
+                    return ToolResult(error="NEO is indivisible; amount must be a whole number")
+                transfer_call = token_contract.transfer(
+                    source=account.script_hash,
+                    destination=to_address,
+                    amount=int(amount_float),
+                )
+            else:
+                transfer_call = token_contract.transfer_friendly(
+                    source=account.script_hash,
+                    destination=to_address,
+                    amount=amount_float,
+                    decimals=decimals,
+                )
+
+            # Execute transaction
+            source_address = str(account.address)
+
+            if wait_for_receipt:
+                receipt = await facade.invoke(transfer_call)
+                state_str = "HALT" if str(receipt.state) == "VMState.HALT" or "HALT" in str(receipt.state) else str(receipt.state)
+                success = "HALT" in state_str
+
+                result = {
+                    "tx_hash": str(receipt.tx_hash),
+                    "success": success,
+                    "state": state_str,
+                    "gas_consumed": receipt.gas_consumed,
+                    "included_in_block": receipt.included_in_block,
+                    "confirmations": receipt.confirmations,
+                    "from": source_address,
+                    "to": to_address,
+                    "amount": amount,
+                    "token": token,
+                    "network": network,
+                }
+
+                if receipt.exception:
+                    result["exception"] = receipt.exception
+
+                if not success:
+                    return ToolResult(error=f"Transaction failed: {receipt.exception or state_str}", output=result)
+
+                return ToolResult(output=result)
+            else:
+                tx_hash = await facade.invoke_fast(transfer_call)
+                return ToolResult(output={
+                    "tx_hash": str(tx_hash),
+                    "status": "submitted",
+                    "from": source_address,
+                    "to": to_address,
+                    "amount": amount,
+                    "token": token,
+                    "network": network,
+                })
+
+        except Exception as e:
+            err_msg = str(e) or repr(e)
+            logger.error(f"NeoTransferTool error: {err_msg}")
+            return ToolResult(error=f"Transfer failed: {err_msg}")
+
+
+class NeoNep11TransferTool(BaseTool):
+    """Transfer a non-divisible NFT (NEP-11) on the Neo N3 blockchain.
+
+    Transfers ownership of an NFT token to a destination address.
+    The sender must be the current owner of the token.
+    """
+
+    name: str = "neo_nep11_transfer"
+    description: str = (
+        "Transfer a non-divisible NFT (NEP-11 standard) on the Neo N3 blockchain. "
+        "Useful when you need to send an NFT to another address. "
+        "The sender must own the token. Returns transaction hash and status."
+    )
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "network": {
+                "type": "string",
+                "enum": ["mainnet", "testnet"],
+                "description": "Neo network to use",
+                "default": "testnet",
+            },
+            "contract_hash": {
+                "type": "string",
+                "description": "NEP-11 NFT contract hash (0x-prefixed)",
+            },
+            "to_address": {
+                "type": "string",
+                "description": "Recipient Neo address",
+            },
+            "token_id": {
+                "type": "string",
+                "description": "Token ID to transfer (hex-encoded bytes or UTF-8 string)",
+            },
+            "private_key": {
+                "type": "string",
+                "description": "Sender private key (WIF or hex). If omitted, uses NEO_PRIVATE_KEY env var.",
+            },
+        },
+        "required": ["contract_hash", "to_address", "token_id"],
+    }
+
+    network: str = Field(default="testnet")
+    contract_hash: Optional[str] = Field(default=None)
+    to_address: Optional[str] = Field(default=None)
+    token_id: Optional[str] = Field(default=None)
+    private_key: Optional[str] = Field(default=None)
+
+    async def execute(
+        self,
+        contract_hash: Optional[str] = None,
+        to_address: Optional[str] = None,
+        token_id: Optional[str] = None,
+        network: Optional[str] = None,
+        private_key: Optional[str] = None,
+    ) -> ToolResult:
+        try:
+            network = network or self.network or "testnet"
+            contract_hash = contract_hash or self.contract_hash
+            to_address = to_address or self.to_address
+            token_id = token_id or self.token_id
+            private_key = private_key or self.private_key
+
+            if not contract_hash:
+                return ToolResult(error="Missing contract_hash parameter")
+            if not to_address:
+                return ToolResult(error="Missing to_address parameter")
+            if not token_id:
+                return ToolResult(error="Missing token_id parameter")
+
+            try:
+                key = _resolve_private_key(private_key)
+            except ValueError as e:
+                return ToolResult(error=str(e))
+
+            try:
+                account = _create_neo3_account(key)
+            except Exception as e:
+                return ToolResult(error=f"Failed to create account from private key: {e}")
+
+            from neo3.api.wrappers import ChainFacade, NEP11NonDivisibleContract
+            from neo3.api.helpers.signing import sign_with_account
+            from neo3.network.payloads.verification import Signer
+            from neo3.core import types
+
+            rpc_url = _get_rpc_url(network)
+            facade = ChainFacade(rpc_host=rpc_url)
+            facade.add_signer(
+                sign_with_account(account),
+                Signer(account.script_hash),
+            )
+
+            if not contract_hash.startswith("0x"):
+                contract_hash = f"0x{contract_hash}"
+            nft_contract = NEP11NonDivisibleContract(
+                types.UInt160.from_string(contract_hash)
+            )
+
+            # Parse token_id: try hex first, fall back to UTF-8 encoding
+            try:
+                tid_hex = token_id
+                if tid_hex.startswith("0x"):
+                    tid_hex = tid_hex[2:]
+                token_id_bytes = bytes.fromhex(tid_hex)
+            except ValueError:
+                token_id_bytes = token_id.encode("utf-8")
+
+            transfer_call = nft_contract.transfer(
+                destination=to_address,
+                token_id=token_id_bytes,
+            )
+
+            source_address = str(account.address)
+            receipt = await facade.invoke(transfer_call)
+            state_str = "HALT" if "HALT" in str(receipt.state) else str(receipt.state)
+            success = "HALT" in state_str
+
+            result = {
+                "tx_hash": str(receipt.tx_hash),
+                "success": success,
+                "state": state_str,
+                "gas_consumed": receipt.gas_consumed,
+                "included_in_block": receipt.included_in_block,
+                "from": source_address,
+                "to": to_address,
+                "contract": contract_hash,
+                "token_id": token_id,
+                "network": network,
+            }
+
+            if receipt.exception:
+                result["exception"] = receipt.exception
+
+            if not success:
+                return ToolResult(error=f"NFT transfer failed: {receipt.exception or state_str}", output=result)
+
+            return ToolResult(output=result)
+
+        except Exception as e:
+            err_msg = str(e) or repr(e)
+            logger.error(f"NeoNep11TransferTool error: {err_msg}")
+            return ToolResult(error=f"NFT transfer failed: {err_msg}")


### PR DESCRIPTION
## Summary
- Add 12 Neo N3 on-chain operation tools built on neo-mamba's ChainFacade
- Add `_compat.py` — idempotent neo-mamba compatibility patches (error handling + timeout)
- Add `neo_transaction_tools_demo.py` — comprehensive demo with read-only and live modes

## New Tools (12)

**Read-only (5, no private key needed):**
| Tool | File | Description |
|------|------|-------------|
| NeoGetBalanceTool | balance_tools.py | Query NEP-17 token balances |
| NeoTestInvokeTool | invoke_tools.py | Test invoke contracts (free, read-only) |
| NeoEstimateGasTool | invoke_tools.py | Estimate GAS cost before sending |
| NeoMultiSigCreateTool | multisig_tools.py | Create multi-signature accounts |
| NeoContractStorageTool | storage_tools.py | Query contract storage entries |

**Transaction (7, require NEO_PRIVATE_KEY):**
| Tool | File | Description |
|------|------|-------------|
| NeoTransferTool | transfer_tools.py | Transfer NEO/GAS/NEP-17 tokens |
| NeoNep11TransferTool | transfer_tools.py | Transfer NEP-11 NFTs |
| NeoInvokeContractTool | invoke_tools.py | State-changing contract invocation |
| NeoBatchInvokeTool | invoke_tools.py | Batch multiple calls in one tx |
| NeoClaimGasTool | governance_action_tools.py | Claim unclaimed GAS |
| NeoVoteTool | governance_action_tools.py | Vote for consensus candidates |
| NeoDeployContractTool | deploy_tools.py | Deploy smart contracts |

## Architecture
- `_compat.py` patches applied once via `__init__.py` before any tool import
- Patches fix two neo-mamba bugs: `_do_post` error handling crash + 3s default timeout
- Subclassing not viable (upstream uses explicit `super(NeoRpcClient, self)` causing recursion)
